### PR TITLE
feat: add enmasse resources to showcase deployment

### DIFF
--- a/openshift/datasync-showcase-community.yml
+++ b/openshift/datasync-showcase-community.yml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: ionic-showcase-server
+  template: ionic-showcase-server-community
 metadata:
-  name: datasync-showcase-server
+  name: datasync-showcase-server-community
   annotations:
-    openshift.io/display-name: Data Sync Showcase 
+    openshift.io/display-name: Data Sync Showcase (Community)
     description: |-
         This template allows for the deployment of the Data Sync Example Showcase App.
         The Data Sync Example Showcase App contains an example Node.js server implementation that 
@@ -258,6 +258,8 @@ objects:
         - env:
             - name: DB_HOSTNAME
               value: "${DATABASE_SERVICE_NAME}"
+            - name: MQTT_HOST
+              value: mosquitto-mqtt-broker
           image: ionic-showcase-server:latest
           name: ionic-showcase-server
           ports:
@@ -320,6 +322,66 @@ objects:
     to:
       kind: Service
       name: "${SERVER_SERVICE_NAME}"
+
+- kind: DeploymentConfig
+  apiVersion: v1
+  name: mosquitto-mqtt-broker
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: ionic-showcase-server
+    name: mosquitto-mqtt-broker
+  spec:
+    replicas: 1
+    selector:
+      app: ionic-showcase-server
+      deploymentconfig: mosquitto-mqtt-broker
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftNewApp
+        creationTimestamp: null
+        labels:
+          app: ionic-showcase-server
+          deploymentconfig: mosquitto-mqtt-broker
+      spec:
+        containers:
+          - name: mosquitto-mqtt-broker
+            image: eclipse-mosquitto:latest
+            ports:
+              - containerPort: 1883
+                protocol: TCP
+    strategy: 
+      type: Rolling
+    paused: false 
+    revisionHistoryLimit: 2 
+    minReadySeconds: 0
+
+- apiVersion: v1
+  kind: Service
+  metadata:
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: ionic-showcase-server
+    name: mosquitto-mqtt-broker
+  spec:
+    ports:
+    - name: 1883-tcp
+      port: 1883
+      protocol: TCP
+      targetPort: 1883
+    selector:
+      app: ionic-showcase-server
+      deploymentconfig: mosquitto-mqtt-broker
+  status:
+    loadBalancer: {}
+
 parameters:
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit

--- a/openshift/datasync-showcase-no-amq.yml
+++ b/openshift/datasync-showcase-no-amq.yml
@@ -320,34 +320,6 @@ objects:
     to:
       kind: Service
       name: "${SERVER_SERVICE_NAME}"
-- apiVersion: enmasse.io/v1beta1
-  kind: AddressSpace
-  metadata:
-    name: showcase
-  spec:
-    type: brokered
-    plan: brokered-single-broker
-- apiVersion: enmasse.io/v1beta1
-  kind: Address
-  metadata:
-      name: showcase.tasks # must have be in format <address space name>.<queuename>
-  spec:
-      address: tasks
-      type: topic
-      plan: brokered-topic
-- apiVersion: user.enmasse.io/v1beta1
-  kind: MessagingUser
-  metadata:
-    name: showcase.showcase-messaging-user
-  spec:
-    username: showcase-messaging-user
-    authentication:
-      type: password
-      # create your own password with echo <password> | base64
-      password: UGFzc3dvcmQx # (base64 encoded) Password1
-    authorization:
-      - addresses: ["*"]
-        operations: ["send", "recv"]
 parameters:
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit

--- a/openshift/datasync-showcase.yml
+++ b/openshift/datasync-showcase.yml
@@ -338,13 +338,12 @@ objects:
 - apiVersion: user.enmasse.io/v1beta1
   kind: MessagingUser
   metadata:
-    name: showcase.showcase-messaging-user
+    name: showcase.${AMQ_USERNAME}
   spec:
-    username: showcase-messaging-user
+    username: ${AMQ_USERNAME}
     authentication:
       type: password
-      # create your own password with echo <password> | base64
-      password: UGFzc3dvcmQx # (base64 encoded) Password1
+      password: ${AMQ_USER_PASSWORD}
     authorization:
       - addresses: ["*"]
         operations: ["send", "recv"]
@@ -385,3 +384,11 @@ parameters:
   displayName: Ionic Server Service name
   name: SERVER_SERVICE_NAME
   value: ionic-showcase-server
+- description: Messaging user created in AMQ Online. The showcase server will authenticate with AMQ as this user.
+  displayName: AMQ Messaging User Name
+  name: AMQ_USERNAME
+  value: showcase-messaging-user
+- description: Create your own password with `$ echo <password> | base64` - the default password is Password1
+  displayName: AMQ Messaging User Password
+  name: AMQ_USER_PASSWORD
+  value: UGFzc3dvcmQx # (base64 encoded) Password1


### PR DESCRIPTION
What this PR does:

* Adds the necessary resources needed to set up the AMQ Online / enmasse integration in the showcase server in `datasync-showcase.yml`
* makes a copy of the original `datasync-showcase.yml` called `datasync-showcase-no-amq.yml` file that can be referenced for upstream docs/examples without the need of AMQ Online.