### PR TITLE
fix: add all possible mqtt related env vars to server deployment

### DIFF
--- a/openshift/datasync-showcase.yml
+++ b/openshift/datasync-showcase.yml
@@ -230,6 +230,12 @@ objects:
   status:
     lastVersion: 0
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: showcase-mqtt-credentials
+  data:
+    MQTT_PASSWORD: ${AMQ_USER_PASSWORD}
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     annotations:
@@ -258,6 +264,17 @@ objects:
         - env:
             - name: DB_HOSTNAME
               value: "${DATABASE_SERVICE_NAME}"
+            - name: MQTT_USERNAME
+              value: "${AMQ_USERNAME}"
+            - name: MQTT_PORT
+              value: "5671"
+            - name: MQTT_PROTOCOL
+              value: "tls"
+            - name: MQTT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: showcase-mqtt-credentials
+                  key: MQTT_PASSWORD
           image: ionic-showcase-server:latest
           name: ionic-showcase-server
           ports:


### PR DESCRIPTION
This PR simply adds some env vars that were not being included

* MQTT_PASSWORD
* MQTT_PROTOCOL
* MQTT_PORT
* MQTT_USERNAME

The only missing thing is MQTT_HOST but this needs to be added after the template is created as the host is only know at that point.

It is a minor convenience but it is possible to update the config with necessary value using a one line command. Working on documentation for that now. This should help simplify the data sync walkthrough we'll be doing if it is based around the showcase.