### PR TITLE
fix: multiple issues in templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Prerequisites
 There are a number of Data Sync OpenShift Templates available.
 
 * [Data Sync App](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-http.yml) - Deploys a custom built Data Sync Application. Uses Node s2i to build the image from source code.
-* [Data Sync Showcase](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application. This includes a postgres storage, a Persistent Volume for file storage, and a Mosca MQTT Broker for a quick and simple getting started experience.
+* [Data Sync Showcase](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application. This includes a postgres storage, a Persistent Volume for file storage, and a Mosquitto MQTT Broker for a quick and simple getting started experience.
 * [Data Sync Showcase With AMQ](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase-amq.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application. This includes a postgres storage, a Persistent Volume for file storage, and resources in AMQ Online for subscriptions.
 
 The templates can be installed into a given namespace.

--- a/README.md
+++ b/README.md
@@ -20,18 +20,18 @@ Prerequisites
 There are a number of Data Sync OpenShift Templates available.
 
 * [Data Sync App](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-http.yml) - Deploys a custom built Data Sync Application. Uses Node s2i to build the image from source code.
-* [Data Sync Showcase](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application. This includes a postgres storage, a Persistent Volume for file storage, and resources in AMQ Online for subscriptions.
-* [Data Sync Showcase Community](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase-community.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application , but replaces Red Hat AMQ Online with [Mosquitto](https://mosquitto.org/) as the MQTT broker.
+* [Data Sync Showcase](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application. This includes a postgres storage, a Persistent Volume for file storage, and a Mosca MQTT Broker for a quick and simple getting started experience.
+* [Data Sync Showcase With AMQ](https://github.com/aerogear/datasync-deployment/blob/master/openshift/datasync-showcase-amq.yml) - Deploys the server component from the [Ionic Showcase](https://github.com/aerogear/ionic-showcase) application. This includes a postgres storage, a Persistent Volume for file storage, and resources in AMQ Online for subscriptions.
 
 The templates can be installed into a given namespace.
 
 ```
 oc create -f https://raw.githubusercontent.com/aerogear/datasync-deployment/master/openshift/datasync-http.yml -n <namespace>
 oc create -f https://raw.githubusercontent.com/aerogear/datasync-deployment/master/openshift/datasync-showcase.yml -n <namespace>
-oc create -f https://raw.githubusercontent.com/aerogear/datasync-deployment/master/openshift/datasync-showcase-community.yml -n <namespace>
+oc create -f https://raw.githubusercontent.com/aerogear/datasync-deployment/master/openshift/datasync-showcase-amq.yml -n <namespace>
 ```
 
-# Deploying the Showcase Server from the Service Catalog
+# Deploying the Showcase Server with AMQ
 
 Prerequisites
 
@@ -39,8 +39,6 @@ Prerequisites
 * AMQ Online is installed in the cluster
 
 This section describes how to deploy the showcase in an Integreatly cluster from the OpenShift Service Catalog.
-
-* Create a new project or namespace in the OpenShift Web Console
 * In the new project use the 'Search Catalog' bar to search for 'Data Sync Showcase'
 * The form is already prefilled with all of the necessary values.
 * The only field you might want to change is `AMQ Messaging User Password`.

--- a/openshift/datasync-showcase-amq.yml
+++ b/openshift/datasync-showcase-amq.yml
@@ -300,6 +300,10 @@ objects:
     to:
       kind: Service
       name: "${SERVER_SERVICE_NAME}"
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Allow
+
 - apiVersion: enmasse.io/v1beta1
   kind: AddressSpace
   metadata:

--- a/openshift/datasync-showcase-amq.yml
+++ b/openshift/datasync-showcase-amq.yml
@@ -5,7 +5,7 @@ kind: Template
 labels:
   template: ionic-showcase-server
 metadata:
-  name: datasync-showcase-server
+  name: datasync-showcase-server-amq
   annotations:
     openshift.io/display-name: Data Sync Showcase With AMQ
     description: |-
@@ -156,79 +156,42 @@ objects:
       type: ImageChange
     - type: ConfigChange
   status: {}
+
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
-    labels:
-      app: ionic-showcase-server
-    name: node
-  spec:
-    lookupPolicy:
-      local: false
-    tags:
-    - annotations:
-        openshift.io/imported-from: node:8
-      from:
-        kind: DockerImage
-        name: node:8
-      generation: null
-      importPolicy: {}
-      name: "8"
-      referencePolicy:
-        type: ""
-  status:
-    dockerImageRepository: ""
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
     labels:
       app: ionic-showcase-server
     name: ionic-showcase-server
-  spec:
-    lookupPolicy:
-      local: false
-  status:
-    dockerImageRepository: ""
+
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
     labels:
       app: ionic-showcase-server
     name: ionic-showcase-server
   spec:
-    nodeSelector: null
     output:
       to:
         kind: ImageStreamTag
         name: ionic-showcase-server:latest
-    postCommit: {}
-    resources: {}
     source:
       contextDir: server
       git:
         uri: https://github.com/aerogear/ionic-showcase
       type: Git
     strategy:
-      dockerStrategy:
+      sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: node:8
-      type: Docker
+          namespace: openshift
+          name: nodejs:10
+      type: Source
     triggers:
     - type: ConfigChange
     - imageChange: {}
       type: ImageChange
-  status:
-    lastVersion: 0
+
 - apiVersion: v1
   kind: Secret
   metadata:

--- a/openshift/datasync-showcase-amq.yml
+++ b/openshift/datasync-showcase-amq.yml
@@ -3,11 +3,11 @@
 apiVersion: v1
 kind: Template
 labels:
-  template: ionic-showcase-server-community
+  template: ionic-showcase-server
 metadata:
-  name: datasync-showcase-server-community
+  name: datasync-showcase-server
   annotations:
-    openshift.io/display-name: Data Sync Showcase (Community)
+    openshift.io/display-name: Data Sync Showcase With AMQ
     description: |-
         This template allows for the deployment of the Data Sync Example Showcase App.
         The Data Sync Example Showcase App contains an example Node.js server implementation that 
@@ -230,6 +230,12 @@ objects:
   status:
     lastVersion: 0
 - apiVersion: v1
+  kind: Secret
+  metadata:
+    name: showcase-mqtt-credentials
+  data:
+    MQTT_PASSWORD: ${AMQ_USER_PASSWORD}
+- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     annotations:
@@ -258,8 +264,17 @@ objects:
         - env:
             - name: DB_HOSTNAME
               value: "${DATABASE_SERVICE_NAME}"
-            - name: MQTT_HOST
-              value: mosquitto-mqtt-broker
+            - name: MQTT_USERNAME
+              value: "${AMQ_USERNAME}"
+            - name: MQTT_PORT
+              value: "5671"
+            - name: MQTT_PROTOCOL
+              value: "tls"
+            - name: MQTT_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: showcase-mqtt-credentials
+                  key: MQTT_PASSWORD
           image: ionic-showcase-server:latest
           name: ionic-showcase-server
           ports:
@@ -322,66 +337,33 @@ objects:
     to:
       kind: Service
       name: "${SERVER_SERVICE_NAME}"
-
-- kind: DeploymentConfig
-  apiVersion: v1
-  name: mosquitto-mqtt-broker
+- apiVersion: enmasse.io/v1beta1
+  kind: AddressSpace
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
-    labels:
-      app: ionic-showcase-server
-    name: mosquitto-mqtt-broker
+    name: showcase
   spec:
-    replicas: 1
-    selector:
-      app: ionic-showcase-server
-      deploymentconfig: mosquitto-mqtt-broker
-    strategy:
-      resources: {}
-    template:
-      metadata:
-        annotations:
-          openshift.io/generated-by: OpenShiftNewApp
-        creationTimestamp: null
-        labels:
-          app: ionic-showcase-server
-          deploymentconfig: mosquitto-mqtt-broker
-      spec:
-        containers:
-          - name: mosquitto-mqtt-broker
-            image: eclipse-mosquitto:latest
-            ports:
-              - containerPort: 1883
-                protocol: TCP
-    strategy: 
-      type: Rolling
-    paused: false 
-    revisionHistoryLimit: 2 
-    minReadySeconds: 0
-
-- apiVersion: v1
-  kind: Service
+    type: brokered
+    plan: brokered-single-broker
+- apiVersion: enmasse.io/v1beta1
+  kind: Address
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
-    labels:
-      app: ionic-showcase-server
-    name: mosquitto-mqtt-broker
+      name: showcase.tasks # must have be in format <address space name>.<queuename>
   spec:
-    ports:
-    - name: 1883-tcp
-      port: 1883
-      protocol: TCP
-      targetPort: 1883
-    selector:
-      app: ionic-showcase-server
-      deploymentconfig: mosquitto-mqtt-broker
-  status:
-    loadBalancer: {}
-
+      address: tasks
+      type: topic
+      plan: brokered-topic
+- apiVersion: user.enmasse.io/v1beta1
+  kind: MessagingUser
+  metadata:
+    name: showcase.${AMQ_USERNAME}
+  spec:
+    username: ${AMQ_USERNAME}
+    authentication:
+      type: password
+      password: ${AMQ_USER_PASSWORD}
+    authorization:
+      - addresses: ["*"]
+        operations: ["send", "recv"]
 parameters:
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
@@ -419,3 +401,11 @@ parameters:
   displayName: Ionic Server Service name
   name: SERVER_SERVICE_NAME
   value: ionic-showcase-server
+- description: Messaging user created in AMQ Online. The showcase server will authenticate with AMQ as this user.
+  displayName: AMQ Messaging User Name
+  name: AMQ_USERNAME
+  value: showcase-messaging-user
+- description: Create your own password with `$ echo <password> | base64` - the default password is Password1
+  displayName: AMQ Messaging User Password
+  name: AMQ_USER_PASSWORD
+  value: UGFzc3dvcmQx # (base64 encoded) Password1

--- a/openshift/datasync-showcase.yml
+++ b/openshift/datasync-showcase.yml
@@ -7,7 +7,7 @@ labels:
 metadata:
   name: datasync-showcase-server
   annotations:
-    openshift.io/display-name: Data Sync Showcase (test)
+    openshift.io/display-name: Data Sync Showcase
     description: |-
         This template allows for the deployment of the Data Sync Example Showcase App.
         The Data Sync Example Showcase App contains an example Node.js server implementation that 

--- a/openshift/datasync-showcase.yml
+++ b/openshift/datasync-showcase.yml
@@ -7,7 +7,7 @@ labels:
 metadata:
   name: datasync-showcase-server
   annotations:
-    openshift.io/display-name: Data Sync Showcase 
+    openshift.io/display-name: Data Sync Showcase
     description: |-
         This template allows for the deployment of the Data Sync Example Showcase App.
         The Data Sync Example Showcase App contains an example Node.js server implementation that 
@@ -230,12 +230,6 @@ objects:
   status:
     lastVersion: 0
 - apiVersion: v1
-  kind: Secret
-  metadata:
-    name: showcase-mqtt-credentials
-  data:
-    MQTT_PASSWORD: ${AMQ_USER_PASSWORD}
-- apiVersion: v1
   kind: DeploymentConfig
   metadata:
     annotations:
@@ -264,17 +258,8 @@ objects:
         - env:
             - name: DB_HOSTNAME
               value: "${DATABASE_SERVICE_NAME}"
-            - name: MQTT_USERNAME
-              value: "${AMQ_USERNAME}"
-            - name: MQTT_PORT
-              value: "5671"
-            - name: MQTT_PROTOCOL
-              value: "tls"
-            - name: MQTT_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: showcase-mqtt-credentials
-                  key: MQTT_PASSWORD
+            - name: MQTT_HOST
+              value: mosquitto-mqtt-broker
           image: ionic-showcase-server:latest
           name: ionic-showcase-server
           ports:
@@ -337,33 +322,66 @@ objects:
     to:
       kind: Service
       name: "${SERVER_SERVICE_NAME}"
-- apiVersion: enmasse.io/v1beta1
-  kind: AddressSpace
+
+- kind: DeploymentConfig
+  apiVersion: v1
+  name: mosquitto-mqtt-broker
   metadata:
-    name: showcase
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: ionic-showcase-server
+    name: mosquitto-mqtt-broker
   spec:
-    type: brokered
-    plan: brokered-single-broker
-- apiVersion: enmasse.io/v1beta1
-  kind: Address
+    replicas: 1
+    selector:
+      app: ionic-showcase-server
+      deploymentconfig: mosquitto-mqtt-broker
+    strategy:
+      resources: {}
+    template:
+      metadata:
+        annotations:
+          openshift.io/generated-by: OpenShiftNewApp
+        creationTimestamp: null
+        labels:
+          app: ionic-showcase-server
+          deploymentconfig: mosquitto-mqtt-broker
+      spec:
+        containers:
+          - name: mosquitto-mqtt-broker
+            image: eclipse-mosquitto:latest
+            ports:
+              - containerPort: 1883
+                protocol: TCP
+    strategy: 
+      type: Rolling
+    paused: false 
+    revisionHistoryLimit: 2 
+    minReadySeconds: 0
+
+- apiVersion: v1
+  kind: Service
   metadata:
-      name: showcase.tasks # must have be in format <address space name>.<queuename>
+    annotations:
+      openshift.io/generated-by: OpenShiftNewApp
+    creationTimestamp: null
+    labels:
+      app: ionic-showcase-server
+    name: mosquitto-mqtt-broker
   spec:
-      address: tasks
-      type: topic
-      plan: brokered-topic
-- apiVersion: user.enmasse.io/v1beta1
-  kind: MessagingUser
-  metadata:
-    name: showcase.${AMQ_USERNAME}
-  spec:
-    username: ${AMQ_USERNAME}
-    authentication:
-      type: password
-      password: ${AMQ_USER_PASSWORD}
-    authorization:
-      - addresses: ["*"]
-        operations: ["send", "recv"]
+    ports:
+    - name: 1883-tcp
+      port: 1883
+      protocol: TCP
+      targetPort: 1883
+    selector:
+      app: ionic-showcase-server
+      deploymentconfig: mosquitto-mqtt-broker
+  status:
+    loadBalancer: {}
+
 parameters:
 - description: Maximum amount of memory the container can use.
   displayName: Memory Limit
@@ -401,11 +419,3 @@ parameters:
   displayName: Ionic Server Service name
   name: SERVER_SERVICE_NAME
   value: ionic-showcase-server
-- description: Messaging user created in AMQ Online. The showcase server will authenticate with AMQ as this user.
-  displayName: AMQ Messaging User Name
-  name: AMQ_USERNAME
-  value: showcase-messaging-user
-- description: Create your own password with `$ echo <password> | base64` - the default password is Password1
-  displayName: AMQ Messaging User Password
-  name: AMQ_USER_PASSWORD
-  value: UGFzc3dvcmQx # (base64 encoded) Password1

--- a/openshift/datasync-showcase.yml
+++ b/openshift/datasync-showcase.yml
@@ -284,6 +284,9 @@ objects:
     to:
       kind: Service
       name: "${SERVER_SERVICE_NAME}"
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Allow
 
 - kind: DeploymentConfig
   apiVersion: v1

--- a/openshift/datasync-showcase.yml
+++ b/openshift/datasync-showcase.yml
@@ -7,7 +7,7 @@ labels:
 metadata:
   name: datasync-showcase-server
   annotations:
-    openshift.io/display-name: Data Sync Showcase
+    openshift.io/display-name: Data Sync Showcase (test)
     description: |-
         This template allows for the deployment of the Data Sync Example Showcase App.
         The Data Sync Example Showcase App contains an example Node.js server implementation that 
@@ -156,79 +156,41 @@ objects:
       type: ImageChange
     - type: ConfigChange
   status: {}
+
 - apiVersion: v1
   kind: ImageStream
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
-    labels:
-      app: ionic-showcase-server
-    name: node
-  spec:
-    lookupPolicy:
-      local: false
-    tags:
-    - annotations:
-        openshift.io/imported-from: node:8
-      from:
-        kind: DockerImage
-        name: node:8
-      generation: null
-      importPolicy: {}
-      name: "8"
-      referencePolicy:
-        type: ""
-  status:
-    dockerImageRepository: ""
-- apiVersion: v1
-  kind: ImageStream
-  metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
     labels:
       app: ionic-showcase-server
     name: ionic-showcase-server
-  spec:
-    lookupPolicy:
-      local: false
-  status:
-    dockerImageRepository: ""
+    
 - apiVersion: v1
   kind: BuildConfig
   metadata:
-    annotations:
-      openshift.io/generated-by: OpenShiftNewApp
-    creationTimestamp: null
     labels:
       app: ionic-showcase-server
     name: ionic-showcase-server
   spec:
-    nodeSelector: null
     output:
       to:
         kind: ImageStreamTag
         name: ionic-showcase-server:latest
-    postCommit: {}
-    resources: {}
     source:
       contextDir: server
       git:
         uri: https://github.com/aerogear/ionic-showcase
       type: Git
     strategy:
-      dockerStrategy:
+      sourceStrategy:
         from:
           kind: ImageStreamTag
-          name: node:8
-      type: Docker
+          namespace: openshift
+          name: nodejs:10
+      type: Source
     triggers:
     - type: ConfigChange
     - imageChange: {}
       type: ImageChange
-  status:
-    lastVersion: 0
 - apiVersion: v1
   kind: DeploymentConfig
   metadata:


### PR DESCRIPTION
* Use Mosca in the main showcase template, there is also a showcase template that does have AMQ (Can be manually installed on a project level) https://issues.jboss.org/browse/AEROGEAR-9707
* Use Official Red Hat Node.js Imagestream from the `openshift` namespace - https://issues.jboss.org/browse/AEROGEAR-9693
* Use a HTTPS route that still also allows HTTP traffic - https://issues.jboss.org/browse/AEROGEAR-9708