### PR TITLE
fix: use https for route in datasync-http.yml

### DIFF
--- a/openshift/datasync-http.yml
+++ b/openshift/datasync-http.yml
@@ -43,6 +43,9 @@ objects:
     to:
       kind: Service
       name: "${NAME}"
+    tls:
+      termination: edge
+      insecureEdgeTerminationPolicy: Allow
 - kind: ImageStream
   apiVersion: v1
   metadata:


### PR DESCRIPTION
You can verify that by checking this project where a sample server was provisioned

https://master.dbizzarr-bdd9.open.redhat.com/console/project/darahayes-test/overview